### PR TITLE
Fixed typographical error, changed auxilary to auxiliary in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Robots:
 ```
 
 Also by default, any page with 'ShowInSearch' set to false will also be excluded. This
-can be useful for hiding auxilary pages like "thanks for signing up", or error pages.
+can be useful for hiding auxiliary pages like "thanks for signing up", or error pages.
 
 You can turn this off (if you really absolutely think you need to) using the below
 


### PR DESCRIPTION
tractorcow, I've corrected a typographical error in the documentation of the [silverstripe-robots](https://github.com/tractorcow/silverstripe-robots) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.