### PR TITLE
5.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ as it's designed to cater to the 99.9% of cases which won't require manual confi
 
 ## Requirements
 
- * SilverStripe 4 or above
+ * Silverstripe 4 or above
 
 ## Installation Instructions
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     },
     "require": {
-        "silverstripe/framework": "^4"
+        "silverstripe/framework": "^4 || ^5"
     },
     "suggest": {
         "silverstripe/googlesitemaps": "Ensures that a valid sitemap.xml is generated and referenced within robots.txt"


### PR DESCRIPTION
Since README already says "SilverStripe 4 or above" I didn't make any further adjustments. As I'm looking at it again, well without camelcase now.